### PR TITLE
spell mistake app:beforeMount

### DIFF
--- a/articles/nuxt3-new-features.md
+++ b/articles/nuxt3-new-features.md
@@ -553,7 +553,7 @@ export default defineNuxtPlugin(nuxtApp => {
 
 また `nuxtApp.hook()` はコールバックに渡した関数を以下の指定した Nuxt ライフサイクルで実行することができます。
 
-- app:beforeMounnt
+- app:beforeMount
 - app:created
 - app:mounted
 - app:rendered


### PR DESCRIPTION
`app:beforeMounnt` -> `app:beforeMount`

スペルミスと思われる箇所がありましたので、修正提案を投げさせていただきます！

（いつもZennの記事参考にさせていただいています！ありがとうございます）

参考：
https://v3.nuxtjs.org/api/advanced/hooks/